### PR TITLE
Add direct routes for easy copy paste of the repo url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 Rails.application.routes.draw do
   root to: 'repositories#index'
 
-  get 'repo/*repo/tag/*tag', to: 'tags#show',         as: :tag       , constraints: { repo: /.+/, tag: /[^\/]+/ }
-  get 'repo/*repo',          to: 'repositories#show', as: :repository, constraints: { repo: /.+/ }
+  get 'repo/*repo/tag/*tag',    to: 'tags#show',         as: :tag,         constraints: {repo: /.+/, tag: /[^\/]+/}
+  get 'repo/*repo',             to: 'repositories#show', as: :repository,  constraints: {repo: /.+/}
 
-  delete 'repo/*repo/tag/*tag', to: 'tags#destroy', constraints: { repo: /.+/, tag: /[^\/]+/ }
+  get '*repo:*tag',             to: redirect('repo/%{repo}/tag/%{tag}'),   constraints: {repo: /.+/, tag: /[^\/]+/}
+  get '*repo',                  to: redirect('repo/%{repo}'),              constraints: {repo: /.+/}
 
-  get :ping, to: Proc.new { [200, {'Content-Type' => 'text/plain'}, ['pong']] }
+  delete 'repo/*repo/tag/*tag', to: 'tags#destroy',                              constraints: {repo: /.+/, tag: /[^\/]+/}
+
+  get :ping, to: Proc.new {[200, {'Content-Type' => 'text/plain'}, ['pong']]}
 end

--- a/spec/routing/repo_routing_spec.rb
+++ b/spec/routing/repo_routing_spec.rb
@@ -9,3 +9,9 @@ describe "routes for repos" do
     )
   end
 end
+
+describe "routes redirect for repos", type: :request do
+  it "routes GET /foo.bar to the tags controller" do
+    expect(get("/foo.bar")).to redirect_to('/repo/foo.bar')
+  end
+end

--- a/spec/routing/tag_routing_spec.rb
+++ b/spec/routing/tag_routing_spec.rb
@@ -28,3 +28,13 @@ describe "routes for tags" do
     )
   end
 end
+
+describe "routes redirect for tags", type: :request do
+  it "routes GET /foo.bar:latest to the tags controller" do
+    expect(get("/foo.bar:latest")).to redirect_to('/repo/foo.bar/tag/latest')
+  end
+
+  it "routes GET /foo/bar:1.2.3 to the tags controller" do
+    expect(get("/foo/bar:1.2.3")).to redirect_to('/repo/foo/bar/tag/1.2.3')
+  end
+end


### PR DESCRIPTION
In our cluster we have made the registry available at the /v2 path and all other goes to the browser.
Now when we have a url like: `domain.com/namespace/image:tag` I won't to be able to paste this into the browser and see the image tag.
Now the URL is slightly different and makes copy paste sometimes hard.

With the given example the url needs to be: `https://domain.com/repo/:namespace/:image/tag/:tag`

This pull request fixes this and allows to copy paste the image tags.