### PR TITLE
Improve Travis build times by caching the bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
     - master
 
 language: ruby
+cache: bundler
 
 rvm:
   - 2.6.3


### PR DESCRIPTION
Improve Travis build times by caching the bundle