### PR TITLE
add `ADDRESS` and `SSL_ADDRESS` options to puma config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,23 @@ docker run --name registry-browser -it -p 8080:8080 -e DOCKER_REGISTRY_URL=http:
 
 The configuration is done by environment variables.
 
-| Option                 | Required | Type   | Description                                                                                    |
-| ---------------------- | -------- | ------ | ---------------------------------------------------------------------------------------------- |
-| `DOCKER_REGISTRY_URL`  | yes      | String | URL to the Docker Registry which should be browsed<br>**Example**: `http://your-registry:5000` |
-| `NO_SSL_VERIFICATION`  | no       | Bool   | Enable to skip SSL verification (default `false`)<br>**Example**: `true`                       |
-| `BASIC_AUTH_USER`      | no       | String | Username for basic-auth against registry<br>**Example**: `joe`                                 |
-| `BASIC_AUTH_PASSWORD`  | no       | String | Password for basic-auth against registry<br>**Example**: `supersecretpassw0rd`                 |
-| `TOKEN_AUTH_USER`      | no       | String | Username for token-auth against registry<br>**Example**: `joe`                                 |
-| `TOKEN_AUTH_PASSWORD`  | no       | String | Password for token-auth against registry<br>**Example**: `supersecretpassw0rd`                 |
-| `ENABLE_DELETE_IMAGES` | no       | Bool   | Allow deletion of tags (default `false`)<br>**Example**: `true`                                |
-| `PUBLIC_REGISTRY_URL`  | no       | String | The public URL to the Docker Registry to do docker pull<br>**Example**: `your-registry:5000`   |
-| `PORT`                 | no       | Number | The port on which the application will serve HTTP requests.<br>**Default**: `8080`             |
-| `SSL_PORT`             | no       | Number | The port on which the application will serve HTTPS requests.<br>**Default**: `8443`            |
-| `SSL_CERT_PATH`        | no       | String | Absolute path to the SSL certificate which should be used.<br>**Example**: `/ssl/cert.pem`     |
-| `SSL_KEY_PATH`         | no       | String | Absolute path to the SSL private key which should be used.<br>**Example**: `/ssl/key.pem`      |
-| `RAILS_RELATIVE_URL_ROOT ` | no       | String | Serve the application under a subpath  (default `/`)<br>**Example**: `/registry-browser`       |
+| Option                     | Type   | Description                                                                                    |
+| -------------------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `DOCKER_REGISTRY_URL`      | String | URL to the Docker Registry which should be browsed<br>**Default**: `http://localhost:5000`     |
+| `NO_SSL_VERIFICATION`      | Bool   | Enable to skip SSL verification (default `false`)<br>**Example**: `true`                       |
+| `BASIC_AUTH_USER`          | String | Username for basic-auth against registry<br>**Example**: `joe`                                 |
+| `BASIC_AUTH_PASSWORD`      | String | Password for basic-auth against registry<br>**Example**: `supersecretpassw0rd`                 |
+| `TOKEN_AUTH_USER`          | String | Username for token-auth against registry<br>**Example**: `joe`                                 |
+| `TOKEN_AUTH_PASSWORD`      | String | Password for token-auth against registry<br>**Example**: `supersecretpassw0rd`                 |
+| `ENABLE_DELETE_IMAGES`     | Bool   | Allow deletion of tags (default `false`)<br>**Example**: `true`                                |
+| `PUBLIC_REGISTRY_URL`      | String | The public URL to the Docker Registry to do docker pull<br>**Example**: `your-registry:5000`   |
+| `ADDRESS`                  | String | The address on which the application will serve HTTP requests.<br>**Default**: `0.0.0.0`       |
+| `PORT`                     | Number | The port on which the application will serve HTTP requests.<br>**Default**: `8080`             |
+| `SSL_ADDRESS`              | String | The address on which the application will serve HTTPS requests.<br>**Default**: `0.0.0.0`      |
+| `SSL_PORT`                 | Number | The port on which the application will serve HTTPS requests.<br>**Default**: `8443`            |
+| `SSL_CERT_PATH`            | String | Absolute path to the SSL certificate which should be used.<br>**Example**: `/ssl/cert.pem`     |
+| `SSL_KEY_PATH`             | String | Absolute path to the SSL private key which should be used.<br>**Example**: `/ssl/key.pem`      |
+| `RAILS_RELATIVE_URL_ROOT ` | String | Serve the application under a subpath (default `/`)<br>**Example**: `/registry-browser`        |
 
 You can also set the following variables as [Docker Swarm secrets](https://docs.docker.com/engine/swarm/secrets/) with the same naming:
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,7 +10,12 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+# port        ENV.fetch("PORT") { 3000 }
+
+address = ENV.fetch("ADDRESS", "0.0.0.0")
+port    = ENV.fetch("PORT", "3000")
+
+bind "tcp://#{address}:#{port}"
 
 # Specifies the `environment` that Puma will run in.
 #
@@ -37,7 +42,7 @@ plugin :tmp_restart
 # custom
 
 if (cert = ENV["SSL_CERT_PATH"]) && (key = ENV["SSL_KEY_PATH"])
-  ssl_bind "0.0.0.0", ENV.fetch("SSL_PORT", "8443"), {
+  ssl_bind ENV.fetch("SSL_ADDRESS", "0.0.0.0"), ENV.fetch("SSL_PORT", "8443"), {
     cert: cert,
     key:  key
   }


### PR DESCRIPTION
This should allow to run the application only on `localhost/127.0.0.1` for example.
Requested in #234.