### PR TITLE
Allow Faraday to follow remote redirects

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -12,6 +12,7 @@ class Resource
       elsif (token = Current.http_token_auth).present?
         f.request :oauth2, token, token_type: :bearer
       end
+      f.use FaradayMiddleware::FollowRedirects, limit: 5
       f.use FaradayMiddleware::ParseJson, content_type: /json|prettyjws/
       f.response :logger unless Rails.env.test?
       f.response :raise_error


### PR DESCRIPTION
A fix for #245 I raised earlier.

Changed with reference to https://github.com/lostisland/faraday_middleware/issues/32