### PR TITLE
improve token auth support

### DIFF
--- a/app/services/obtain_authentication_token.rb
+++ b/app/services/obtain_authentication_token.rb
@@ -14,7 +14,8 @@ class ObtainAuthenticationToken
   attr_accessor :realm, :service, :scope
 
   def perform_request
-    client.get(realm, params).body.fetch('token')
+    resp = client.get(realm, params)
+    resp.body['token'] || resp.body['access_token']
   end
 
   def params

--- a/spec/services/obtain_authentication_token_spec.rb
+++ b/spec/services/obtain_authentication_token_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ObtainAuthenticationToken do
 
     let(:response_body) do
       {
-        token: token
+        access_token: token
       }
     end
 
@@ -45,8 +45,22 @@ RSpec.describe ObtainAuthenticationToken do
       expect(stubbed_request).to have_been_made
     end
 
-    it 'returns the received token' do
-      expect(instance.call).to eq token
+    context 'with the new oauth2 compatible response format' do
+      it 'returns the received token' do
+        expect(instance.call).to eq token
+      end
+    end
+
+    context 'with the old response format' do
+      let(:response_body) do
+        {
+          token: token
+        }
+      end
+
+      it 'returns the received token' do
+        expect(instance.call).to eq token
+      end
     end
   end
 end


### PR DESCRIPTION
support both `token` and `access_token` attributes in response

fix for #255