### PR TITLE
gracefully handle token auth issues

### DIFF
--- a/app/services/obtain_authentication_token.rb
+++ b/app/services/obtain_authentication_token.rb
@@ -1,4 +1,6 @@
 class ObtainAuthenticationToken
+  InvalidCredentials = Class.new(RuntimeError)
+
   def initialize(auth_params)
     @realm   = auth_params.fetch('realm')
     @service = auth_params.fetch('service')
@@ -16,6 +18,9 @@ class ObtainAuthenticationToken
   def perform_request
     resp = client.get(realm, params)
     resp.body['token'] || resp.body['access_token']
+  rescue Faraday::ClientError => e
+    raise InvalidCredentials if e.response[:status] == 401
+    raise e
   end
 
   def params

--- a/app/views/errors/auth_attempts_exceeded.html.erb
+++ b/app/views/errors/auth_attempts_exceeded.html.erb
@@ -1,0 +1,11 @@
+<div class="text-center mt-5">
+  <h1 class="cover-heading">Error</h1>
+
+  <p class="lead">The obtained bearer token was rejected by the registry.</p>
+
+  <p>
+    Please verify the ACLs to ensure the configured user has the required permissions.
+    <br />
+    Delete session cookies to retry.
+  </p>
+</div>

--- a/app/views/errors/invalid_credentials.html.erb
+++ b/app/views/errors/invalid_credentials.html.erb
@@ -1,0 +1,11 @@
+<div class="text-center mt-5">
+  <h1 class="cover-heading">Error</h1>
+
+  <p class="lead">Could not obtain token with configured credentials.</p>
+
+  <p>
+    Please verify the username and password.
+    <br />
+    Delete session cookies to retry.
+  </p>
+</div>

--- a/spec/features/token_auth_spec.rb
+++ b/spec/features/token_auth_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+feature 'Token Auth' do
+  include TokenAuthHelpers
+
+  before do
+    configure_token_auth
+    stub_token_auth_requests
+  end
+
+  scenario 'Successful listing empty catalog' do
+    stub_catalog_requests [
+      token_auth_required_response,
+      empty_catalog_response
+    ]
+
+    visit '/'
+
+    expect(page).to have_text 'No repositories'
+  end
+
+  scenario 'Failed listing of catalog due to ACL issue' do
+    stub_catalog_requests [token_auth_required_response]
+
+    visit '/'
+
+    expect(page).to have_text 'The obtained bearer token was rejected by the registry'
+  end
+
+  scenario 'Successful listing of catalog and repository' do
+    stub_catalog_requests [token_auth_required_response, successful_catalog_response]
+    stub_repository_requests [token_auth_required_response, successful_repository_response]
+
+    visit '/'
+    click_link 'repository'
+
+    expect(page).to have_text 'Image'
+    expect(page).to have_text 'repository'
+    expect(page).to have_text 'Tag'
+    expect(page).to have_text 'latest'
+  end
+
+  scenario 'Successful listing of catalog but failed request of repository' do
+    stub_catalog_requests [token_auth_required_response, successful_catalog_response]
+    stub_repository_requests [token_auth_required_response]
+
+    visit '/'
+    click_link 'repository'
+
+    expect(page).to have_text 'The obtained bearer token was rejected by the registry'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/services/obtain_authentication_token_spec.rb
+++ b/spec/services/obtain_authentication_token_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe ObtainAuthenticationToken do
     let(:service) { 'registry.example.com' }
     let(:scope)   { 'repository:hello/world:pull,push' }
 
+    let(:response_status) { 200 }
+
     let(:response_body) do
       {
         access_token: token
@@ -36,7 +38,7 @@ RSpec.describe ObtainAuthenticationToken do
         offline_token: true,
         scope:         scope,
         service:       service
-      }).to_return(body: response_body.to_json, headers: response_headers)
+      }).to_return(status: response_status, body: response_body.to_json, headers: response_headers)
     end
 
     it 'sends a request to the realm' do
@@ -60,6 +62,14 @@ RSpec.describe ObtainAuthenticationToken do
 
       it 'returns the received token' do
         expect(instance.call).to eq token
+      end
+    end
+
+    context 'then the response is http 401' do
+      let(:response_status) { 401 }
+
+      it 'raises a custom error' do
+        expect { instance.call }.to raise_error ObtainAuthenticationToken::InvalidCredentials
       end
     end
   end

--- a/spec/services/obtain_authentication_token_spec.rb
+++ b/spec/services/obtain_authentication_token_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ObtainAuthenticationToken do
       end
     end
 
-    context 'then the response is http 401' do
+    context 'when the response is http 401' do
       let(:response_status) { 401 }
 
       it 'raises a custom error' do

--- a/spec/support/helpers/token_auth_helpers.rb
+++ b/spec/support/helpers/token_auth_helpers.rb
@@ -1,0 +1,54 @@
+module TokenAuthHelpers
+  def configure_token_auth
+    allow(Rails.configuration.x).to receive(:token_auth_user).and_return('admin')
+    allow(Rails.configuration.x).to receive(:token_auth_password).and_return('badmin')
+  end
+
+  def stub_catalog_requests(responses = [empty_catalog_response])
+    stub_request(:get, 'http://localhost:5000/v2/_catalog?n=100').to_return(responses)
+  end
+
+  def stub_repository_requests(responses = [successful_repository_response])
+    stub_request(:get, 'http://localhost:5000/v2/repository/tags/list').to_return(responses)
+  end
+
+  def stub_token_auth_requests
+    stub_request(:get, 'https://auth.example.com/token?client_id=docker-registry-browser&offline_token=true&scope=catalog:*&service=Docker%20Registry').to_return(
+      status:  200,
+      headers: { 'Content-Type' => 'application/json' },
+      body:    { token: 'the-access-token' }.to_json
+    )
+  end
+
+  def token_auth_required_response
+    {
+      status: 401, headers: {
+        'www-authenticate' => 'bearer realm="https://auth.example.com/token" service="Docker Registry" scope="catalog:*"'
+      }
+    }
+  end
+
+  def empty_catalog_response
+    {
+      status:  200,
+      headers: { 'Content-Type' => 'application/json' },
+      body:    { repositories: []}.to_json
+    }
+  end
+
+  def successful_catalog_response
+    {
+      status:  200,
+      headers: { 'Content-Type' => 'application/json' },
+      body:    { repositories: ['repository']}.to_json
+    }
+  end
+
+  def successful_repository_response
+    {
+      status:  200,
+      headers: { 'Content-Type' => 'application/json' },
+      body:    { tags: ['latest'] }.to_json
+    }
+  end
+end


### PR DESCRIPTION
showing proper error pages in case invalid credentials for token auth are configured or the  user doesn't have the required permissions.

See: #295