### PR TITLE
token based auth without hardcoded credentials

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -7,10 +7,10 @@ class Resource
         f.use Faraday::Request::BasicAuthentication,
           Rails.configuration.x.basic_auth_user,
           Rails.configuration.x.basic_auth_password
-      elsif (auth = Current.http_basic_auth).present?
-        f.use Faraday::Request::BasicAuthentication, *auth
       elsif (token = Current.http_token_auth).present?
         f.request :oauth2, token, token_type: :bearer
+      elsif (auth = Current.http_basic_auth).present?
+        f.use Faraday::Request::BasicAuthentication, *auth
       end
       f.use FaradayMiddleware::FollowRedirects, limit: 5
       f.use FaradayMiddleware::ParseJson, content_type: /json|prettyjws/

--- a/spec/services/obtain_authentication_token_spec.rb
+++ b/spec/services/obtain_authentication_token_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ObtainAuthenticationToken do
   describe '#call' do
-    let(:instance) { described_class.new(params) }
+    let(:instance) { described_class.new(params, credentials) }
 
     let(:params) do
       {
@@ -10,6 +10,13 @@ RSpec.describe ObtainAuthenticationToken do
         'service' => service,
         'scope'   => scope
       }
+    end
+
+    let(:credentials) do
+      [
+        'username',
+        'password'
+      ]
     end
 
     let(:realm)   { 'https://auth.example.com/token' }


### PR DESCRIPTION
In addition to support the static configuration of credentials used to obtain auth tokens this PR will fallback to request them from the browser if they are not configured.

Requested in #313