### PR TITLE
implement params to define tags sort order

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,5 +1,12 @@
 class RepositoriesController < ApplicationController
   helper_method :configs
+  helper_method :sort_tags_by
+  helper_method :sort_tags_order
+
+  after_action do
+    cookies.permanent[:sort_tags_by]    = sort_tags_by
+    cookies.permanent[:sort_tags_order] = sort_tags_order
+  end
 
   def index
     @repositories = Repository.list(last: params[:last])
@@ -8,11 +15,27 @@ class RepositoriesController < ApplicationController
 
   def show
     @repository = Repository.find params[:repo]
+    @tags       = sort_tags
   end
 
   private
 
   def configs
     Rails.application.config.x
+  end
+
+  def sort_tags
+    tags = @repository.tags
+    tags = tags.sort    if sort_tags_by    == "name"
+    tags = tags.reverse if sort_tags_order == "desc"
+    tags
+  end
+
+  def sort_tags_by
+    params[:sort_tags_by] || cookies[:sort_tags_by] || configs.sort_tags_by
+  end
+
+  def sort_tags_order
+    params[:sort_tags_order] || cookies[:sort_tags_order] || configs.sort_tags_order
   end
 end

--- a/app/views/repositories/_sort_links.html.erb
+++ b/app/views/repositories/_sort_links.html.erb
@@ -1,0 +1,14 @@
+<p class="text-right">
+  <small>
+    <strong>Sort:</strong> [
+      <%= link_to "API", {sort_tags_by: "api", sort_tags_order: sort_tags_order}, class: {"text-reset": true, "font-weight-bold": sort_tags_by == "api"} %>
+      |
+      <%= link_to "Name", {sort_tags_by: "name", order: sort_tags_order}, class: {"text-reset": true, "font-weight-bold": sort_tags_by == "name"} %>
+    ]
+    <strong>Order:</strong> [
+      <%= link_to "ASC", {sort_tags_order: "asc", sort_tags_by: sort_tags_by}, class: {"text-reset": true, "font-weight-bold": sort_tags_order == "asc"} %>
+      |
+      <%= link_to "DESC", {sort_tags_order: "desc", sort_tags_by: sort_tags_by}, class: {"text-reset": true, "font-weight-bold": sort_tags_order == "desc"} %>
+    ]
+  </small>
+</p>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -12,11 +12,13 @@
 
         <span class="text-muted small">Image</span>
         <h5 class="card-title mb-0"><%= @repository.image %></h5>
+
+        <%= render "sort_links" %>
       <% end %>
 
-      <% if @repository.tags.any? %>
+      <% if @tags.any? %>
         <div class="list-group list-group-flush">
-          <% @repository.tags.sort.reverse.each do |tag| %>
+          <% @tags.each do |tag| %>
             <% if Rails.configuration.x.public_registry_url %>
               <div class="copy-to-clipboard-icon">
                 <%= render partial: "shared/copy_to_clipboard", locals: { name: :pull_cmd, value: pull_command(@repository.name, tag), style: "icon" } %>

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -11,4 +11,6 @@ Rails.application.config.tap do |config|
   config.x.delete_enabled      = Config.get(name: "ENABLE_DELETE_IMAGES").in? %w(1 true yes)
   config.x.public_registry_url = Config.get(name: "PUBLIC_REGISTRY_URL")
   config.x.collapse_namespaces = Config.get(name: "ENABLE_COLLAPSE_NAMESPACES").in? %w(1 true yes)
+  config.x.sort_tags_by        = Config.get(name: "SORT_TAGS_BY", default: "name", allow: %w(api name))
+  config.x.sort_tags_order     = Config.get(name: "SORT_TAGS_ORDER", default: "desc", allow: %w(asc desc))
 end

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ This option defines where the application will load it's SSL key from.
 
 Default: Not used
 
-### Features
+### Features / User Interface
 
 #### `ENABLE_COLLAPSE_NAMESPACES`
 
@@ -97,6 +97,32 @@ Please note that this button will only work when the delete feature is also enab
 See https://docs.docker.com/registry/configuration/#delete for details.
 
 Default: `false`
+
+#### `SORT_TAGS_BY`
+
+This option allows to define the default sort criteria for the tags list.
+
+It is used whenever the user has no custom selection (cookie).
+
+Possible values:
+
+* `api`: Keep the sort as provided by the registry API
+* `name`: Sort the tags in alphabetical order
+
+Default: `name`
+
+#### `SORT_TAGS_ORDER`
+
+This option allows to define the default sort order for the tags list.
+
+It is used whenever the user has no custom selection (cookie).
+
+Possible values:
+
+* `asc`: Normal sort order
+* `desc`: Inverse sort order
+
+Default: `desc`
 
 ### Connection to the Registry
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,13 +1,17 @@
 module Config
   extend self
 
-  def get(name:, default: nil, secret: false)
-    if secret && File.file?("/run/secrets/#{name}")
+  def get(name:, default: nil, secret: false, allow: nil)
+    value = if secret && File.file?("/run/secrets/#{name}")
       File.read("/run/secrets/#{name}").strip
     elsif ENV.key?(name)
       ENV[name]
     else
       default
     end
+
+    raise ArgumentError, "#{name} must be one of #{allow}" if allow.is_a?(Array) && !value.in?(allow)
+
+    value
   end
 end

--- a/spec/features/show_image_spec.rb
+++ b/spec/features/show_image_spec.rb
@@ -10,8 +10,12 @@ feature "Image details" do
     expect(page).to have_content "/"
     expect(page).to have_content "Image"
     expect(page).to have_content "hello-world"
-    expect(page).to have_content "latest"
-    expect(page).to have_content "v1"
-    expect(page).to have_content "v2"
+    expect(page).to have_content "Tag v2\nTag v1\nTag latest"
+  end
+
+  scenario "Use custom sort for tags", :vcr do
+    visit "/repo/hello-world?sort_tags_by=api&sort_tags_order=asc"
+
+    expect(page).to have_content "Tag v2\nTag latest\nTag v1"
   end
 end

--- a/spec/fixtures/vcr_cassettes/Image_details/Use_custom_sort_for_tags.yml
+++ b/spec/fixtures/vcr_cassettes/Image_details/Use_custom_sort_for_tags.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/_catalog?n=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 07 Nov 2019 15:10:23 GMT
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: '{"repositories":["hello-world","test/hello-world","test/hello-world-1","test/hello-world-2","test/hello-world-3"]}
+
+        '
+    http_version: 
+  recorded_at: Thu, 07 Nov 2019 15:10:23 GMT
+- request:
+    method: get
+    uri: http://localhost:5000/v2/hello-world/tags/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 07 Nov 2019 15:10:23 GMT
+      Content-Length:
+      - '51'
+    body:
+      encoding: UTF-8
+      string: '{"name":"hello-world","tags":["v2","latest","v1"]}
+
+        '
+    http_version: 
+  recorded_at: Thu, 07 Nov 2019 15:10:23 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
Allow user to change how the tags are sorted

* Links in UI
* Memorized in Cookie
* Default setting via `ENV`

Addressing feature request #310