### PR TITLE
Fix 500 error when repository API back with null value for repository list

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -5,7 +5,8 @@ class Repository < Resource
 
   def self.list(count: 100, last: nil)
     response = client.get "/v2/_catalog", { n: count, last: last }.compact
-    entries  = response.body["repositories"].map { |name| new(name: name) }
+    repositories = response.body["repositories"] || []
+    entries  = repositories.map { |name| new(name: name) }
 
     Collection.new entries: entries, more: response.headers.has_key?("Link")
   end


### PR DESCRIPTION
Hi. 

During work with new Azure Container Repository (no created repositories) received 500 error. The API back with `null` value for `repositories` property.

![Screenshot 2022-05-27 at 15 53 38](https://user-images.githubusercontent.com/10552422/170713674-0074b7d5-e8cc-4059-a619-cd43577eb31f.png)

I added a simple condition to avoid this error.

Before fix:

![Screenshot 2022-05-27 at 15 47 21](https://user-images.githubusercontent.com/10552422/170713785-8abfe399-8aa8-4073-8503-afbf6c1f7382.png)

After fix:

![Screenshot 2022-05-27 at 15 47 35](https://user-images.githubusercontent.com/10552422/170713812-3106310c-7afc-4b80-90e8-58d559097962.png)
