### PR TITLE
handle empty history

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -65,7 +65,7 @@ class Tag < Resource
       content_digest: digest,
       created:        (Time.parse(blob.dig("created")) rescue nil),
       env:            blob.dig("config", "Env") || [],
-      history:        (blob.dig("history") || {}).map { |e| HistoryEntry.new(e) },
+      history:        blob.fetch("history", []).map { |e| HistoryEntry.new(e) },
       labels:         blob.dig("config", "Labels") || {},
       layers:         layers,
       size:           layers.sum(&:size),

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -65,7 +65,7 @@ class Tag < Resource
       content_digest: digest,
       created:        (Time.parse(blob.dig("created")) rescue nil),
       env:            blob.dig("config", "Env") || [],
-      history:        blob.dig("history").map { |e| HistoryEntry.new(e) },
+      history:        (blob.dig("history") || {}).map { |e| HistoryEntry.new(e) },
       labels:         blob.dig("config", "Labels") || {},
       layers:         layers,
       size:           layers.sum(&:size),


### PR DESCRIPTION
Hi, 
we store oci (non-docker) images in registry, and `docker-registry-browser` works great until manifest has all the fields set. 
But some fields are actually optional, and in our case it fails like this: 
```
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] NoMethodError (undefined method `map' for nil:NilClass
ui          |
ui          |       history:        blob.dig("history").map { |e| HistoryEntry.new(e) },
ui          |                                          ^^^^):
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9]
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] app/models/tag.rb:68:in `manifest_for_digest'
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] app/models/tag.rb:45:in `fetch_manifests'
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] app/models/tag.rb:20:in `initialize'
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] app/models/tag.rb:14:in `new'
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] app/models/tag.rb:14:in `find'
ui          | [0f85cdec-5daf-4f02-8f62-3280f2962bc9] app/controllers/tags_controller.rb:31:in `find_tag'
```
I'm not a ruby guy, so proposing this quick fix. 