### PR TITLE
Suppress logging of Authorization headers by Faraday

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 docs
 .git
+
+# Ignore JetBrains IDE files
+.idea

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
 docs
+log
+spec
+
 .git
+.gitattributes
+.gitignore
+.github
 
 # Ignore JetBrains IDE files
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore JetBrains IDE files
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# vNext
+
+* Turn off Faraday HTTP request header logging
+* Add environment variable REGISTRY_LOG_LEVEL to set log level Faraday uses when writing registry related log events
+* Add environment variable REGISTRY_LOG_HEADERS to enable Faraday to log HTTP request headers
+
 # v1.5.0
 
 * Handle `null` value in `repositories` property of `/v2/_catalog`

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -14,7 +14,7 @@ class Resource
       end
       f.use FaradayMiddleware::FollowRedirects, limit: 5
       f.use FaradayMiddleware::ParseJson, content_type: /json|prettyjws/
-      f.response :logger unless Rails.env.test?
+      f.response :logger, Rails.configuration.logger, Rails.configuration.x.registry_log_options
       f.response :raise_error
       f.adapter  Faraday.default_adapter
     end

--- a/app/services/obtain_authentication_token.rb
+++ b/app/services/obtain_authentication_token.rb
@@ -37,7 +37,7 @@ class ObtainAuthenticationToken
     Faraday.new url: realm, ssl: ssl_options do |f|
       f.use Faraday::Request::BasicAuthentication, *creds
       f.use FaradayMiddleware::ParseJson, content_type: /json|prettyjws/
-      f.response :logger unless Rails.env.test?
+      f.response :logger, Rails.configuration.logger, Rails.configuration.x.registry_log_options
       f.response :raise_error
       f.adapter Faraday.default_adapter
     end

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -13,4 +13,13 @@ Rails.application.config.tap do |config|
   config.x.collapse_namespaces = Config.get(name: "ENABLE_COLLAPSE_NAMESPACES").in? %w(1 true yes)
   config.x.sort_tags_by        = Config.get(name: "SORT_TAGS_BY", default: "name", allow: %w(api name version))
   config.x.sort_tags_order     = Config.get(name: "SORT_TAGS_ORDER", default: "desc", allow: %w(asc desc))
+
+  # Configure Faraday logger options
+  config.x.registry_log_options = {
+    # Log level must be included by main application log level. E.g. if application log level
+    # is set to :info, and this is set to :debug, no requests will be logged.
+    log_level: Config.get(name: "REGISTRY_LOG_LEVEL", default: "info").to_sym,
+    # Warning - enabling this results in sensitive data such as Authorization headers being logged
+    headers: (Config.get(name: "REGISTRY_LOG_HEADERS", default: "false").in? %w(1 true yes))
+  }
 end

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,10 @@ Please note that this value should only contain the domain and port part of the 
 
 Default: Not used
 
+#### Logging
+
+See [Registry Request Logging](#registry-request-logging)
+
 ### Authentication
 
 The application automatically detects if the docker-registry API requires authentication and forwards that request to the web-browser. As an alternative it's also possible to configure static values to be used in the authentication to allow access with the permissions of an specific user.
@@ -324,3 +328,17 @@ services:
 
 [nginx]: https://www.nginx.com
 [traefik]: https://traefik.io/traefik/
+
+## Logging
+
+### Registry Request Logging
+
+By default, basic information about requests to the registry, such as HTTP method and url, are 
+logged at the `:info` level.
+
+For debugging, you can change two aspects via environment variables:
+
+* `REGISTRY_LOG_LEVEL` - set the log level used to write registry request (and response) events
+* `REGISTRY_LOG_HEADERS` - boolean - enables logging request headers
+
+Due to sensitive data being present in Authorization headers, do not enable header logging in production.


### PR DESCRIPTION
The HTTP `Authorization` header contains security-sensitive information.

By default, when run from the Docker container, the application will log `Authorization` header values at the `:info` level, because this is the default `Faraday` behavior.

Add a configuration point to `application.rb` to suppress this (requests are still logged, just not their headers).

Add overrides to `test` and `development` environments to enable header logging.