### PR TITLE
Allow customizing the catalog page size

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -3,7 +3,7 @@ class Repository < Resource
 
   attr_accessor :name, :tags
 
-  def self.list(count: 100, last: nil)
+  def self.list(count: Rails.configuration.x.catalog_page_size, last: nil)
     response = client.get "/v2/_catalog", { n: count, last: last }.compact
     repositories = response.body["repositories"] || []
     entries  = repositories.map { |name| new(name: name) }

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -13,6 +13,7 @@ Rails.application.config.tap do |config|
   config.x.collapse_namespaces = Config.get(name: "ENABLE_COLLAPSE_NAMESPACES").in? %w(1 true yes)
   config.x.sort_tags_by        = Config.get(name: "SORT_TAGS_BY", default: "name", allow: %w(api name version))
   config.x.sort_tags_order     = Config.get(name: "SORT_TAGS_ORDER", default: "desc", allow: %w(asc desc))
+  config.x.catalog_page_size   = Config.get(name: "CATALOG_PAGE_SIZE", default: 100)
 
   # Configure Faraday logger options
   config.x.registry_log_options = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,12 @@ Possible values:
 
 Default: `desc`
 
+#### `CATALOG_PAGE_SIZE`
+
+This option allows limiting how many images will be listed by page.
+
+Default: `100`
+
 ### Connection to the Registry
 
 #### `DOCKER_REGISTRY_URL`


### PR DESCRIPTION
The number of images listed by page is currently hardcoded to 100, which is the API default.

Allow modifying this number by setting the CATALOG_PAGE_SIZE number.

This option is useful when you have a big number of images on the registry and you don't want to have them paginated. Indirectly allows using `ctrl-f` to search through images, currently not possible if the image is on a different page.