### PR TITLE
fix: Mark vendored bootstrap in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@ db/schema.rb linguist-generated
 vendor/* linguist-vendored
 config/credentials/*.yml.enc diff=rails_credentials
 config/credentials.yml.enc diff=rails_credentials
+
+# Mark vendored bootstrap
+app/assets/stylesheets/_bootstrap.scss linguist-vendored


### PR DESCRIPTION
Attempt of telling GitHub to not detect SCSS as main language in the project.

Before:

* SCSS: 69.2%
* Ruby: 21.7%
* HTML: 7.7%
* Other: 1.4%