### PR TITLE
Enable bundler cache in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-      - name: Install Dependencies
-        run: bundle install
+        with:
+          bundler-cache: true
       - name: Execute Linter
         run: bundle exec rubocop
       - name: Execute Tests


### PR DESCRIPTION
Enable bundler caching for faster dependency installation.